### PR TITLE
Provide setting of a time limit for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Following configuration properties have sensible defaults, but can be modified:
 
 * _type_ - cartridge type, e.g. jbossas-7.0
 * _libraDomain_ - domain where OpenShift server instance is running, e.g. rhcloud.com
+* _deploymentTime_ - a maximal time in ms to finish deployment,e.g. 30000
 
 Following configuration properties are optional
 

--- a/openshift-express/src/main/java/org/jboss/arquillian/container/openshift/express/OpenShiftExpressConfiguration.java
+++ b/openshift-express/src/main/java/org/jboss/arquillian/container/openshift/express/OpenShiftExpressConfiguration.java
@@ -75,6 +75,8 @@ public class OpenShiftExpressConfiguration implements ContainerConfiguration {
     private CartridgeType cartridgeType;
 
     private String passphrase = System.getenv("SSH_PASSPHRASE");
+    
+    private long deploymentTime = 30000;
 
     /*
      * (non-Javadoc)
@@ -253,6 +255,14 @@ public class OpenShiftExpressConfiguration implements ContainerConfiguration {
 
         return new URL(sb.toString());
     }
+
+    public long getDeploymentTime() {
+        return deploymentTime;
+    }
+
+    public void setDeploymentTime(long deploymentTime) {
+        this.deploymentTime = deploymentTime;
+    }    
 
     private URI constructRemoteRepositoryURI() throws URISyntaxException {
         StringBuilder sb = new StringBuilder("ssh://");

--- a/openshift-express/src/main/java/org/jboss/arquillian/container/openshift/express/OpenShiftExpressContainer.java
+++ b/openshift-express/src/main/java/org/jboss/arquillian/container/openshift/express/OpenShiftExpressContainer.java
@@ -233,12 +233,12 @@ public class OpenShiftExpressContainer implements DeployableContainer<OpenShiftE
 
       log.fine("Checking if deployment is deployed: " + url);
 
-      long timeout = System.currentTimeMillis() + 30000;
+      long timeout = System.currentTimeMillis() + configuration.get().getDeploymentTime();
 
       UrlChecker checker = new UrlChecker(timeout, url.toString());
       if (!checker.checkUrlWithRetry())
       {
-         throw new DeploymentException("Following path were not reachable within " + 30000 + " ms after git push. "
+         throw new DeploymentException("Following path were not reachable within " + configuration.get().getDeploymentTime() + " ms after git push. "
                + "Check if following archives are constructed properly:\n" + deploymentName);
       }
    }


### PR DESCRIPTION
I have an application which can't be deployed within 30s (RichFaces showcase). The maximal time for deployment is set to 30s (hardcoded), so the Arquillian container is useless for me. I suggest the time limit as a part of configuration.
